### PR TITLE
Aem 20260312 1550

### DIFF
--- a/blocks/columns/columns.css
+++ b/blocks/columns/columns.css
@@ -647,7 +647,6 @@
     flex-direction: row;
     gap: 0;
     position: relative;
-    border: 1px solid rgb(211 213 225);
   }
 
   .columns.apply > div > div {

--- a/styles/styles.css
+++ b/styles/styles.css
@@ -426,21 +426,19 @@ main .section.white-bg a.button:any-link {
     margin-bottom: 0;
   }
 
- /* Carousel sections: short vertical keyline stub at section boundary only
-     (reference uses 40px up + 40px down = 80px total, not full section height) */
+  /* Carousel sections: 80px vertical stub centered on the horizontal keyline.
+     Non-first carousels: horizontal is at -40px, so vertical runs -80px to 0px
+     (40px above + 40px below the horizontal = cross/intersection pattern).
+     First carousel after hero: horizontal is at 0px, so vertical runs -40px to +40px. */
   /* stylelint-disable no-descending-specificity */
-  main > .section:has(.carousel)::after,
-  main > .section.hero-container + .section:has(.carousel)::after {
+  main > .section:has(.carousel)::after {
+    top: -80px;
     bottom: auto;
     height: 80px;
   }
-  /* stylelint-enable no-descending-specificity */
-  
-  /* Carousel sections: short vertical keyline stub at section boundary only
-     (reference uses 40px up + 40px down = 80px total, not full section height) */
-  /* stylelint-disable no-descending-specificity */
-  main > .section:has(.carousel)::after,
+
   main > .section.hero-container + .section:has(.carousel)::after {
+    top: -40px;
     bottom: auto;
     height: 80px;
   }

--- a/styles/styles.css
+++ b/styles/styles.css
@@ -444,6 +444,25 @@ main .section.white-bg a.button:any-link {
     bottom: auto;
     height: 80px;
   }
+
+  /* Carousel sections: absolute-position the horizontal keyline at the section
+     boundary so it intersects with the vertical ::after (both at top: -40px).
+     Without this, the relative-positioned ::before lands 80px below the section
+     top due to padding, and the lines never cross. */
+  main > .section + .section:has(.carousel)::before {
+    position: absolute;
+    top: -40px;
+    left: 30px;
+    right: 30px;
+    max-width: none;
+    margin: 0;
+  }
+
+  /* First carousel after hero: keep horizontal flush at section boundary (top: 0)
+     since the hero section has no keyline stubs extending below */
+  main > .section.hero-container + .section:has(.carousel)::before {
+    top: 0;
+  }
   /* stylelint-enable no-descending-specificity */
 
   /* Vertical stub below discover section into gap before testimonial
@@ -515,6 +534,29 @@ main .section.white-bg a.button:any-link {
     top: 0;
     bottom: auto;
     height: 175px;
+    z-index: 1;
+  }
+
+  /* Search/Advisor section: re-enable horizontal keyline at top boundary */
+  /* stylelint-disable-next-line no-descending-specificity */
+  main > .section.muted-blue:has(.columns.apply)::before {
+    display: block;
+    position: absolute;
+    top: -40px;
+    left: 30px;
+    right: 30px;
+    max-width: none;
+    margin: 0;
+    z-index: 1;
+  }
+
+  /* Search/Advisor section: re-enable center vertical keyline, extend into footer */
+  /* stylelint-disable-next-line no-descending-specificity */
+  main > .section.muted-blue:has(.columns.apply)::after {
+    display: block;
+    top: -40px;
+    bottom: -40px;
+    height: auto;
     z-index: 1;
   }
 

--- a/styles/styles.css
+++ b/styles/styles.css
@@ -426,6 +426,17 @@ main .section.white-bg a.button:any-link {
     margin-bottom: 0;
   }
 
+  /* Carousel sections: hide vertical and horizontal keylines
+     (role finder pages have no keylines through carousel card areas) */
+  /* stylelint-disable no-descending-specificity */
+  main > .section:has(.carousel)::before,
+  main > .section:has(.carousel)::after,
+  main > .section.hero-container + .section:has(.carousel)::before,
+  main > .section.hero-container + .section:has(.carousel)::after {
+    display: none;
+  }
+  /* stylelint-enable no-descending-specificity */
+
   /* Vertical stub below discover section into gap before testimonial
      (testimonial ::after with top: -40px bridges this gap from below) */
 
@@ -479,6 +490,7 @@ main .section.white-bg a.button:any-link {
   /* Horizontal keyline after testimonial: flush with boat image bottom */
   /* stylelint-disable-next-line no-descending-specificity */
   main > .section.muted-blue:has(.columns-img-col) + .section::before {
+    display: block;
     position: absolute;
     top: 0;
     left: 30px;
@@ -490,6 +502,7 @@ main .section.white-bg a.button:any-link {
 
   /* Vertical line after testimonial: only 175px into carousel, not full section */
   main > .section.muted-blue:has(.columns-img-col) + .section::after {
+    display: block;
     top: 0;
     bottom: auto;
     height: 175px;

--- a/styles/styles.css
+++ b/styles/styles.css
@@ -426,6 +426,16 @@ main .section.white-bg a.button:any-link {
     margin-bottom: 0;
   }
 
+ /* Carousel sections: short vertical keyline stub at section boundary only
+     (reference uses 40px up + 40px down = 80px total, not full section height) */
+  /* stylelint-disable no-descending-specificity */
+  main > .section:has(.carousel)::after,
+  main > .section.hero-container + .section:has(.carousel)::after {
+    bottom: auto;
+    height: 80px;
+  }
+  /* stylelint-enable no-descending-specificity */
+  
   /* Carousel sections: short vertical keyline stub at section boundary only
      (reference uses 40px up + 40px down = 80px total, not full section height) */
   /* stylelint-disable no-descending-specificity */

--- a/styles/styles.css
+++ b/styles/styles.css
@@ -426,14 +426,13 @@ main .section.white-bg a.button:any-link {
     margin-bottom: 0;
   }
 
-  /* Carousel sections: hide vertical and horizontal keylines
-     (role finder pages have no keylines through carousel card areas) */
+  /* Carousel sections: short vertical keyline stub at section boundary only
+     (reference uses 40px up + 40px down = 80px total, not full section height) */
   /* stylelint-disable no-descending-specificity */
-  main > .section:has(.carousel)::before,
   main > .section:has(.carousel)::after,
-  main > .section.hero-container + .section:has(.carousel)::before,
   main > .section.hero-container + .section:has(.carousel)::after {
-    display: none;
+    bottom: auto;
+    height: 80px;
   }
   /* stylelint-enable no-descending-specificity */
 

--- a/styles/styles.css
+++ b/styles/styles.css
@@ -340,9 +340,10 @@ main > .section.white-bg::before {
   display: none;
 }
 
-/* Apply section (Search roles + Speak to advisor): dark navy background, no keylines */
+/* Apply section (Search roles + Speak to advisor): dark navy background */
 main .section.muted-blue:has(.columns.apply) {
   background-color: var(--background-color);
+  border-bottom: 1px solid rgb(211 213 225);
 }
 
 /* Move testimonial horizontal keyline flush with boat image top */


### PR DESCRIPTION
These are mostly changes for the keylines or piping throughout the page that highlights carousels and search:

Fix #51 

Test URLs:
- Before: https://main--poc-mh--aemdemos.aem.page/careers/find-a-role/engineering
- After: https://aem-20260312-1550--poc-mh--aemdemos.aem.page/careers/find-a-role/engineering